### PR TITLE
Fix parameter in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ module "vpc" {
   private_subnets = "10.0.1.0/24,10.0.2.0/24,10.0.3.0/24"
   public_subnets  = "10.0.101.0/24,10.0.102.0/24,10.0.103.0/24"
 
-  region   = "us-west-2"
   azs      = "us-west-2a,us-west-2b,us-west-2c"
 }
 ```


### PR DESCRIPTION
This module wouldn't accept a region parameter, no matter how hard I tried. ;-)