### PR TITLE
Make subnets optional

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_subnet" "private" {
   vpc_id = "${aws_vpc.mod.id}"
   cidr_block = "${element(split(",", var.private_subnets), count.index)}"
   availability_zone = "${element(split(",", var.azs), count.index)}"
-  count = "${length(split(",", var.private_subnets))}"
+  count = "${length(compact(split(",", var.private_subnets)))}"
   tags { Name = "${var.name}-private" }
 }
 
@@ -33,20 +33,20 @@ resource "aws_subnet" "public" {
   vpc_id = "${aws_vpc.mod.id}"
   cidr_block = "${element(split(",", var.public_subnets), count.index)}"
   availability_zone = "${element(split(",", var.azs), count.index)}"
-  count = "${length(split(",", var.public_subnets))}"
+  count = "${length(compact(split(",", var.public_subnets)))}"
   tags { Name = "${var.name}-public" }
 
   map_public_ip_on_launch = true
 }
 
 resource "aws_route_table_association" "private" {
-  count = "${length(split(",", var.private_subnets))}"
+  count = "${length(compact(split(",", var.private_subnets)))}"
   subnet_id = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${aws_route_table.private.id}"
 }
 
 resource "aws_route_table_association" "public" {
-  count = "${length(split(",", var.public_subnets))}"
+  count = "${length(compact(split(",", var.public_subnets)))}"
   subnet_id = "${element(aws_subnet.public.*.id, count.index)}"
   route_table_id = "${aws_route_table.public.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "name" { }
 variable "cidr" { }
-variable "public_subnets" { }
-variable "private_subnets" { }
+variable "public_subnets" { default = "" }
+variable "private_subnets" { default = "" }
 variable "azs" { }


### PR DESCRIPTION
A couple of small changes to make subnets optional. The first improves the count line, with the addition of compact(). (As discussed in https://github.com/hashicorp/terraform/issues/1604#issuecomment-155567822)

The second adds a default value to the variables to allow them to be made optional. 