### PR TITLE
Adding in enable_dns_hostnames variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Module Input Variables
 - `public_subnets` - comma separated list of public subnet cidrs
 - `private_subnets` - - comma separated list of private subnet cidrs
 - `azs` - comma separated lists of AZs in which to distribute subnets
+- `enable_dns_hostnames` - A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false.
 
 It's generally preferable to keep `public_subnets`, `private_subnets`, and
 `azs` to lists of the same length.
@@ -30,6 +31,8 @@ module "vpc" {
   public_subnets  = "10.0.101.0/24,10.0.102.0/24,10.0.103.0/24"
 
   azs      = "us-west-2a,us-west-2b,us-west-2c"
+
+  enable_dns_hostnames = true
 }
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 resource "aws_vpc" "mod" {
   cidr_block = "${var.cidr}"
   tags { Name = "${var.name}" }
+  enable_dns_hostnames = "${var.enable_dns_hostnames}"
 }
 
 resource "aws_internet_gateway" "mod" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,6 @@ variable "cidr" { }
 variable "public_subnets" { }
 variable "private_subnets" { }
 variable "azs" { }
+variable "enable_dns_hostnames" {
+  default = false
+}


### PR DESCRIPTION
You can enable DNS hostnames now via this variable.  The default is false just like the terraform vpc resource.  Also updated README example