### PR TITLE
add enable_dns_support and enable_dns_hostnames to vpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Module Input Variables
 - `public_subnets` - comma separated list of public subnet cidrs
 - `private_subnets` - - comma separated list of private subnet cidrs
 - `azs` - comma separated lists of AZs in which to distribute subnets
+- `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
+- `enable_dns_support` - should be true if you want to use private DNS within the VPC
 
 It's generally preferable to keep `public_subnets`, `private_subnets`, and
 `azs` to lists of the same length.

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,7 @@
 resource "aws_vpc" "mod" {
   cidr_block = "${var.cidr}"
+  enable_dns_hostnames = "${var.enable_dns_hostnames}"
+  enable_dns_support = "${var.enable_dns_support}"
   tags { Name = "${var.name}" }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,11 @@ variable "cidr" { }
 variable "public_subnets" { }
 variable "private_subnets" { }
 variable "azs" { }
+variable "enable_dns_hostnames" {
+  description = "should be true if you want to use private DNS within the VPC"
+  default = false
+}
+variable "enable_dns_support" {
+  description = "should be true if you want to use private DNS within the VPC"
+  default = false
+}


### PR DESCRIPTION
In order to support private DNS in the VPC both `enable_dns_support` and `enable_dns_hostnames` need to be set. PR #5 only sets `enable_dns_hostnames` so submitting this as well :-)