### PR TITLE
Output private route table id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "public_subnets" {
 output "vpc_id" {
   value = "${aws_vpc.mod.id}"
 }
+
+output "private_route_table_id" {
+  value = "${aws_route_table.private.id}"
+}


### PR DESCRIPTION
When setting up a NAT instance, the private route table needs an extra route to direct outbound traffic to the NAT instance. By outputting the route table id, you can add the route later like this:

```
resource "aws_route" "outbound_internet" {
  route_table_id = "${module.vpc.private_route_table_id}"
  destination_cidr_block = "0.0.0.0/0"
  // TODO: but we've got 2 NAT instances - one in each AZ ...
  instance_id = "${element(split(",", module.nat.instance_ids), 0)}"
}
```
