### PR TITLE
Add public & private routes to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Outputs
  - `vpc_id` - does what it says on the tin
  - `private_subnets` - comma separated list of private subnet ids
  - `public_subnets` - comma separated list of public subnet ids
+ - `public_route_table_id` - public route table id string
+ - `private_route_table_id` - private route table id string
 
 Authors
 =======

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,11 @@ output "public_subnets" {
 output "vpc_id" {
   value = "${aws_vpc.mod.id}"
 }
+
+output "public_route_table_id" {
+  value = "${aws_route_table.public.id}"
+}
+
+output "private_route_table_id" {
+  value = "${aws_route_table.private.id}"
+}


### PR DESCRIPTION
As per the previous pull request, but adding public route tables too.
I didnt want to address the issues in your comment on the other PR @antonbabenko, i feel they are out of scope of this.
I simply want to access the outputs of the created resources.