### PR TITLE
Add the internet gateway id to the module outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "public_route_table_id" {
 output "private_route_table_id" {
   value = "${aws_route_table.private.id}"
 }
+
+output "internet_gateway_id" {
+  value = "${aws_internet_gateway.mod.id"
+}


### PR DESCRIPTION
This is needed to add a NAT Gateway to this VPC since it is recommended that the NAT gateway depends on the IGW (https://www.terraform.io/docs/providers/aws/r/nat_gateway.html)