### PR TITLE
add output default_security_group_id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "public_route_table_id" {
 output "private_route_table_id" {
   value = "${aws_route_table.private.id}"
 }
+
+output "default_security_group_id" {
+  value = "${aws_vpc.mod.default_security_group_id}"
+}


### PR DESCRIPTION
This allows using the default security group of the VPC.
Rules for the security group can be defined outside of this module by using [`security_group_rule`](https://www.terraform.io/docs/providers/aws/r/security_group_rule.html)
