### PR TITLE
Add Tag for Name to Internet Gateway Resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,10 @@ resource "aws_vpc" "mod" {
 
 resource "aws_internet_gateway" "mod" {
   vpc_id = "${aws_vpc.mod.id}"
+
+  tags {
+    Name = "${var.name}-igw"
+  }
 }
 
 resource "aws_route_table" "public" {

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_subnet" "public" {
     Name = "${var.name}-public"
   }
 
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "enable_dns_support" {
   default     = false
 }
 
+variable "map_public_ip_on_launch" {
+  description = "should be false if you do not want to auto-assign public IP on launch"
+  default     = true
+}
+
 variable "private_propagating_vgws" {
   description = "A list of VGWs the private route table should propagate."
   default     = []


### PR DESCRIPTION
Summary of Changes:

Internet Gateway is something that can be tagged with a name, I think it would be worth tagging it similar to the public/private route tables, eg. `myvpc-igw`.

Visually it's faster/easier to look at a list and know what internet gateway is associated with a VPC