### PR TITLE
Add a Tag for Name to Internet Gateway

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,10 @@ resource "aws_vpc" "mod" {
 
 resource "aws_internet_gateway" "mod" {
   vpc_id = "${aws_vpc.mod.id}"
+
+  tags {
+    Name = "${var.name}-igw"
+  }
 }
 
 resource "aws_route_table" "public" {


### PR DESCRIPTION
Summary of Changes:

Internet Gateway is something that can be tagged with a name, I think it would be worth tagging it similar to the public/private route tables, eg. myvpc-igw.

Visually it's faster/easier to look at a list and know what internet gateway is associated with a VPC