### PR TITLE
Add Toggle Variable for map_public_ip_on_launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Module Input Variables
 - `azs` - list of AZs in which to distribute subnets
 - `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
 - `enable_dns_support` - should be true if you want to use private DNS within the VPC
+- `map_public_ip_on_launch` - should be false if you do not want to auto-assign public IP on launch
 - `private_propagating_vgws` - list of VGWs the private route table should propagate
 - `public_propagating_vgws` - list of VGWs the public route table should propagate
 

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_subnet" "public" {
     Name = "${var.name}-public"
   }
 
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "enable_dns_support" {
   default     = false
 }
 
+variable "map_public_ip_on_launch" {
+  description = "should be false if you do not want to auto-assign public IP on launch"
+  default     = true
+}
+
 variable "private_propagating_vgws" {
   description = "A list of VGWs the private route table should propagate."
   default     = []


### PR DESCRIPTION
Summary of Changes

This adds a new variable for `map_public_ip_on_launch`, with a default value of `true`. Having this variable allows users to toggle on/off the auto-assign public IP setting in their VPC. Currently the value is just static.

If you auto assign an IP address, the elastic IP is attached to the instance, when the instance is terminated, the elastic IP is released.

There is use cases where people may want to put an instance in a public subnet, but not auto-assign a public IP, as they may want to consciously assign a specific Elastic IP, not lose that Elastic IP when the instance is terminated, etc.