### PR TITLE
bugfix: create NAT Gateway in public, not private subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ resource "aws_eip" "nateip" {
 
 resource "aws_nat_gateway" "natgw" {
   allocation_id = "${element(aws_eip.nateip.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.private.*.id, count.index)}"
+  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
   count         = "${length(var.private_subnets) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
 
   depends_on = ["aws_internet_gateway.mod"]


### PR DESCRIPTION
oops, my previous patch created a configuration with invalid NAT Gateway
placement; fixed now