### PR TITLE
Update Variables.tf

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -18,12 +18,12 @@ variable "azs" {
 }
 
 variable "enable_dns_hostnames" {
-  description = "should be true if you want to use private DNS within the VPC"
+  description = "should be false if you want to use private DNS within the VPC"
   default     = false
 }
 
 variable "enable_dns_support" {
-  description = "should be true if you want to use private DNS within the VPC"
+  description = "should be false if you want to use private DNS within the VPC"
   default     = false
 }
 


### PR DESCRIPTION
Setting the variables 'enable_dns_support' and 'enable_dns_hostnames' to false allows private DNS servers, and true uses Amazon resources.