### PR TITLE
Add create_before_destroy to subnets to deal with terraform bug

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,10 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_subnet" "private" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   vpc_id            = "${aws_vpc.mod.id}"
   cidr_block        = "${var.private_subnets[count.index]}"
   availability_zone = "${var.azs[count.index]}"
@@ -60,6 +64,10 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_subnet" "public" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   vpc_id            = "${aws_vpc.mod.id}"
   cidr_block        = "${var.public_subnets[count.index]}"
   availability_zone = "${var.azs[count.index]}"


### PR DESCRIPTION
There is an issue when modifying autoscaling groups that the subnets must have create_before_destroy = "true" set. See this bug: https://github.com/hashicorp/terraform/issues/2359