### PR TITLE
Add tags variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Module Input Variables
 - `map_public_ip_on_launch` - should be false if you do not want to auto-assign public IP on launch
 - `private_propagating_vgws` - list of VGWs the private route table should propagate
 - `public_propagating_vgws` - list of VGWs the public route table should propagate
+- `tags` - dictionary of tags that will be added to resources created by the module
 
 It's generally preferable to keep `public_subnets`, `private_subnets`, and
 `azs` to lists of the same length.
@@ -41,6 +42,11 @@ module "vpc" {
   enable_nat_gateway = "true"
 
   azs      = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  
+  tags {
+    "Terraform" = "true"
+    "Environment" = "${var.environment}"
+  }
 }
 ```
 

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,8 @@ variable "public_propagating_vgws" {
   description = "A list of VGWs the public route table should propagate."
   default     = []
 }
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  default     = {}
+}


### PR DESCRIPTION
Allow caller to pass additional tags to be added to all resources.  e.g. this can be used to add a tag defining the environment.

Usage is like:

```
module "vpc" {
    source = "git@github.com:typerlc/tf_aws_vpc.git?ref=add_tags_variable"
    name   = ...
    cidr      = ...

    azs       = ...
    private_subnets = ...
    public_subnets  = ...

    tags {
        "Terraform" = "true"
        "Environment" = "${var.environment}"
    }
}
```