### PR TITLE
Adding the NAT gateways public elastic IPs to the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Outputs
  - `private_route_table_ids` - list of private route table ids
  - `default_security_group_id` - VPC default security group id string
  - `nat_eips` - list of Elastic IP ids (if any are provisioned)
+ - `nat_eip_public_ips` - list of NAT gateways' public Elastic IP's (if any are provisioned)
  - `igw_id` - Internet Gateway id string
 
 **NOTE**: previous versions of this module returned a single string as a route

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Outputs
  - `private_route_table_ids` - list of private route table ids
  - `default_security_group_id` - VPC default security group id string
  - `nat_eips` - list of Elastic IP ids (if any are provisioned)
- - `nat_eip_public_ips` - list of NAT gateways' public Elastic IP's (if any are provisioned)
+ - `nat_eips_public_ips` - list of NAT gateways' public Elastic IP's (if any are provisioned)
  - `igw_id` - Internet Gateway id string
 
 **NOTE**: previous versions of this module returned a single string as a route

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,7 +28,8 @@ output "nat_eips" {
 
 output "nat_eip_public_ips" {
   value = ["${aws_eip.nateip.*.public_ip}"]
-
+}
+  
 output "natgw_ids" {
   value = ["${aws_nat_gateway.natgw.*.id}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,7 +26,7 @@ output "nat_eips" {
   value = ["${aws_eip.nateip.*.id}"]
 }
 
-output "nat_eip_public_ips" {
+output "nat_eips_public_ips" {
   value = ["${aws_eip.nateip.*.public_ip}"]
 }
   

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "nat_eips" {
 output "nat_eips_public_ips" {
   value = ["${aws_eip.nateip.*.public_ip}"]
 }
-  
+
 output "natgw_ids" {
   value = ["${aws_nat_gateway.natgw.*.id}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,9 @@ output "nat_eips" {
   value = ["${aws_eip.nateip.*.id}"]
 }
 
+output "nat_eip_public_ips" {
+  value = ["${aws_eip.nateip.*.public_ip}"]
+
 output "natgw_ids" {
   value = ["${aws_nat_gateway.natgw.*.id}"]
 }


### PR DESCRIPTION
I'm not 100% sure if this is the right way to do it, but I need to use the NAT gateways public elastic IPs as a source address in a security group rule and this is the only way I can get hold of them (or at least I could not figure out any other way).  