### PR TITLE
feature(rds): add rds database subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Module Input Variables
 - `cidr` - vpc cidr
 - `public_subnets` - list of public subnet cidrs
 - `private_subnets` - list of private subnet cidrs
+- `database_subnets` - list of private RDS subnet cidrs
 - `azs` - list of AZs in which to distribute subnets
 - `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
 - `enable_dns_support` - should be true if you want to use private DNS within the VPC
@@ -59,6 +60,7 @@ Outputs
  - `vpc_id` - does what it says on the tin
  - `private_subnets` - list of private subnet ids
  - `public_subnets` - list of public subnet ids
+ - `database_subnets` - list of database subnets ids
  - `public_route_table_ids` - list of public route table ids
  - `private_route_table_ids` - list of private route table ids
  - `default_security_group_id` - VPC default security group id string

--- a/main.tf
+++ b/main.tf
@@ -53,12 +53,11 @@ resource "aws_subnet" "database" {
 }
 
 resource "aws_db_subnet_group" "database" {
-  name        = "${var.name}-database-subnet-group"
+  name        = "${var.name}-rds-subnet-group"
   description = "Database subnet groups for ${var.name}"
   subnet_ids  = ["${aws_subnet.database.*.id}"]
   tags        = "${merge(var.tags, map("Name", format("%s-database-subnet-group", var.name)))}"
-  count       = "${length(var.database_subnets) > 0 ? 1: 0}"
-  depends_on  = ["aws_subnet.database"]
+  count       = "${length(var.database_subnets) > 0 ? 1 : 0}"
 }
 
 resource "aws_subnet" "public" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,14 @@ output "private_subnets" {
   value = ["${aws_subnet.private.*.id}"]
 }
 
+output "database_subnets" {
+  value = ["${aws_subnet.database.*.id}"]
+}
+
+output "database_subnet_group" {
+  value = "${aws_db_subnet_group.database.id}"
+}
+
 output "public_subnets" {
   value = ["${aws_subnet.public.*.id}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,12 @@ variable "private_subnets" {
   default     = []
 }
 
+variable "database_subnets" {
+  type        = "list"
+  description = "A list of database subnets"
+  default     = []
+}
+
 variable "azs" {
   description = "A list of Availability zones in the region"
   default     = []


### PR DESCRIPTION
### Changes introduces by this PR
When building a VPC you may require to add RDS instances into your infrastructure. This might require isolated private subnet groups apart from the existing ones. Below are the changes introduced by this PR.
 
- Add the RDS private database subnets
- Create RDS subnet group
- Associate the subnets with private route tables
- Provide output for the following:
    - A list of database subnet ids
   - The id of the subnet group


### usage

```hcl
module "vpc" {
...
  database_subnets   = ["10.0.90.0/24", "10.0.91.0/24", "10.0.92.0/24"]
....
}

```

Terraform will only provision these resources only when the variable `database_subnets` is provided.