### PR TITLE
Adjusted count of NAT gateways to be dependent upon the number of AZs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_route" "public_internet_gateway" {
 resource "aws_route" "private_nat_gateway" {
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index % length(var.azs))}"
+  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
   count                  = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
 }
 
@@ -86,13 +86,13 @@ resource "aws_nat_gateway" "natgw" {
 resource "aws_route_table_association" "private" {
   count          = "${length(var.private_subnets)}"
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index % length(var.azs))}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "database" {
   count          = "${length(var.database_subnets)}"
   subnet_id      = "${element(aws_subnet.database.*.id, count.index)}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index % length(var.azs))}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
 }
 
 resource "aws_route_table_association" "public" {

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_route" "public_internet_gateway" {
 resource "aws_route" "private_nat_gateway" {
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
+  nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index % length(var.azs))}"
   count                  = "${length(var.private_subnets) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
 }
 
@@ -72,13 +72,13 @@ resource "aws_subnet" "public" {
 
 resource "aws_eip" "nateip" {
   vpc   = true
-  count = "${length(var.private_subnets) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
+  count = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
 }
 
 resource "aws_nat_gateway" "natgw" {
   allocation_id = "${element(aws_eip.nateip.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  count         = "${length(var.private_subnets) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
+  count         = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
 
   depends_on = ["aws_internet_gateway.mod"]
 }


### PR DESCRIPTION
I was using this module for a project that had 9 private subnets and was frustrated when I found I also had 9 NAT gateways.

This change will create one NAT gateway per AZ and the private subnets will end up with routes to the NAT gateway in the same AZ.

This is related to issue #42 