### PR TITLE
add elasticache / elasticache group creation as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Module Input Variables
 - `public_subnets` - list of public subnet cidrs
 - `private_subnets` - list of private subnet cidrs
 - `database_subnets` - list of private RDS subnet cidrs
+- `elasticache_subnets` - list of private Elasticache subnet cidrs
 - `azs` - list of AZs in which to distribute subnets
 - `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
 - `enable_dns_support` - should be true if you want to use private DNS within the VPC
@@ -62,6 +63,8 @@ Outputs
  - `public_subnets` - list of public subnet ids
  - `database_subnets` - list of database subnets ids
  - `database_subnet_group` - db subnet group name
+ - `elasticache_subnets` - list of elasticache subnets ids
+ - `elasticache_subnet_group` - elasticache subnet group name
  - `public_route_table_ids` - list of public route table ids
  - `private_route_table_ids` - list of private route table ids
  - `default_security_group_id` - VPC default security group id string

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,14 @@ output "public_subnets" {
   value = ["${aws_subnet.public.*.id}"]
 }
 
+output "elasticache_subnets" {
+  value = ["${aws_subnet.elasticache.*.id}"]
+}
+
+output "elasticache_subnet_group" {
+  value = "${aws_elasticache_subnet_group.elasticache.id}"
+}
+
 output "vpc_id" {
   value = "${aws_vpc.mod.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "database_subnets" {
   default     = []
 }
 
+variable "elasticache_subnets" {
+  type        = "list"
+  description = "A list of elasticache subnets"
+  default     = []
+}
+
 variable "azs" {
   description = "A list of Availability zones in the region"
   default     = []


### PR DESCRIPTION
Changes introduces by this PR

When building a VPC you may require to add Elasticache instances into your infrastructure. This might require isolated private subnet groups apart from the existing ones. Below are the changes introduced by this PR.

- Add the elasticache private elasticache subnets
- Create elasticache subnet group
- Associate the subnets with private route tables

Provide output for the following:

- A list of elasticache subnet ids
- The id of the elasticache subnet group
usage

```
module "vpc" {
...
  elasticache_subnets   = ["10.0.90.0/24", "10.0.91.0/24", "10.0.92.0/24"]
....
}
```

Terraform will only provision these resources only when the variable elasticache_subnets is provided.