### PR TITLE
remove tags from aws_elasticache_subnet_group stanza

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,6 @@ resource "aws_elasticache_subnet_group" "elasticache" {
   name        = "${var.name}-elasticache-subnet-group"
   description = "Elasticache subnet groups for ${var.name}"
   subnet_ids  = ["${aws_subnet.elasticache.*.id}"]
-  tags        = "${merge(var.tags, map("Name", format("%s-elasticache-subnet-group", var.name)))}"
   count       = "${length(var.elasticache_subnets) > 0 ? 1 : 0}"
 }
 


### PR DESCRIPTION
was getting 

```
> terraform plan
1 error(s) occurred:

* module.tf_aws_vpc.aws_elasticache_subnet_group.elasticache: : invalid or unknown key: tags
```

looks like tags are not a valid argument - https://www.terraform.io/docs/providers/aws/r/elasticache_subnet_group.html

