### PR TITLE
Add the ability to set subnet-type specific tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Module Input Variables
 - `private_propagating_vgws` - list of VGWs the private route table should propagate
 - `public_propagating_vgws` - list of VGWs the public route table should propagate
 - `tags` - dictionary of tags that will be added to resources created by the module
+- `public_subnet_tags` - dictionary of tags to apply to public subnets in addition to those in `tags` variable
+- `private_subnet_tags` - dictionary of tags to apply to private subnets in addition to those in `tags` variable
+- `database_subnet_tags` - dictionary of tags to apply to database subnets in addition to those in `tags` variable
+- `elasticache_subnet_tags` - dictionary of tags to apply to elasticache subnets in addition to those in `tags` variable
 
 It's generally preferable to keep `public_subnets`, `private_subnets`, and
 `azs` to lists of the same length.

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_subnet" "private" {
   cidr_block        = "${var.private_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.private_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-subnet-private-%s", var.name, element(var.azs, count.index))))}"
+  tags              = "${merge(var.private_subnet_tags, merge(var.tags, map("Name", format("%s-subnet-private-%s", var.name, element(var.azs, count.index)))))}"
 }
 
 resource "aws_subnet" "database" {
@@ -49,7 +49,7 @@ resource "aws_subnet" "database" {
   cidr_block        = "${var.database_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.database_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-database-subnet-%s", var.name, element(var.azs, count.index))))}"
+  tags              = "${merge(var.database_subnet_tags, merge(var.tags, map("Name", format("%s-database-subnet-%s", var.name, element(var.azs, count.index)))))}"\n
 }
 
 resource "aws_db_subnet_group" "database" {
@@ -65,7 +65,7 @@ resource "aws_subnet" "elasticache" {
   cidr_block        = "${var.elasticache_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.elasticache_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-elasticache-subnet-%s", var.name, element(var.azs, count.index))))}"
+  tags              = "${merge(elasticache_subnet_tags, merge(var.tags, map("Name", format("%s-elasticache-subnet-%s", var.name, element(var.azs, count.index)))))}"
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
@@ -80,7 +80,7 @@ resource "aws_subnet" "public" {
   cidr_block        = "${var.public_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.public_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-subnet-public-%s", var.name, element(var.azs, count.index))))}"
+  tags              = "${merge(var.public_subnet_tags, merge(var.tags, map("Name", format("%s-subnet-public-%s", var.name, element(var.azs, count.index)))))}"
 
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,23 @@ variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}
 }
+
+variable "public_subnet_tags" {
+  description = "A map of extra tags to add to public subnets"
+  default     = {}
+}
+
+variable "private_subnet_tags" {
+  description = "A map of extra tags to add to private subnets"
+  default     = {}
+}
+
+variable "database_subnet_tags" {
+  description = "A map of extra tags to add to database subnets"
+  default     = {}
+}
+
+variable "elasticache_subnet_tags" {
+  description = "A map of extra tags to add to elasticache subnets"
+  default     = {}
+}


### PR DESCRIPTION
Example use case is to take all private subnets with `type:private` for
use with AWSnycast (from the tf_aws_nat module).