### PR TITLE
Support subnet-specific additional tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_subnet" "private" {
   cidr_block        = "${var.private_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.private_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-subnet-private-%s", var.name, element(var.azs, count.index))), map("Tier", "private"))}"
+  tags              = "${merge(var.tags, var.private_subnet_tags, map("Name", format("%s-subnet-private-%s", var.name, element(var.azs, count.index))))}"
 }
 
 resource "aws_subnet" "database" {
@@ -49,7 +49,7 @@ resource "aws_subnet" "database" {
   cidr_block        = "${var.database_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.database_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-database-subnet-%s", var.name, element(var.azs, count.index))), map("Tier", "database"))}"
+  tags              = "${merge(var.tags, var.database_subnet_tags, map("Name", format("%s-database-subnet-%s", var.name, element(var.azs, count.index))))}"
 }
 
 resource "aws_db_subnet_group" "database" {
@@ -65,7 +65,7 @@ resource "aws_subnet" "elasticache" {
   cidr_block        = "${var.elasticache_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.elasticache_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-elasticache-subnet-%s", var.name, element(var.azs, count.index))), map("Tier", "elasticache"))}"
+  tags              = "${merge(var.tags, var.elasticache_subnet_tags, map("Name", format("%s-elasticache-subnet-%s", var.name, element(var.azs, count.index))))}"
 }
 
 resource "aws_elasticache_subnet_group" "elasticache" {
@@ -80,7 +80,7 @@ resource "aws_subnet" "public" {
   cidr_block        = "${var.public_subnets[count.index]}"
   availability_zone = "${element(var.azs, count.index)}"
   count             = "${length(var.public_subnets)}"
-  tags              = "${merge(var.tags, map("Name", format("%s-subnet-public-%s", var.name, element(var.azs, count.index))), map("Tier", "public"))}"
+  tags              = "${merge(var.tags, var.public_subnet_tags, map("Name", format("%s-subnet-public-%s", var.name, element(var.azs, count.index))))}"
 
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,23 @@ variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}
 }
+
+variable "public_subnet_tags" {
+  description = "Additional tags for the public subnets"
+  default     = {}
+}
+
+variable "private_subnet_tags" {
+  description = "Additional tags for the public subnets"
+  default     = {}
+}
+
+variable "database_subnet_tags" {
+  description = "Additional tags for the database subnets"
+  default     = {}
+}
+
+variable "elasticache_subnet_tags" {
+  description = "Additional tags for the elasticache subnets"
+  default     = {}
+}


### PR DESCRIPTION
* Added var.public_subnet_tags
* Added var.private_subnet_tags
* Added var.database_subnet_tags
* Added var.elasticache_subnet_tags

This helps solve a specific issue with Kubernetes, where public &
private subnets must be appropriately tagged for public/private ELBs to
work.