### PR TITLE
Adding tenancy option for instances launched into the VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Module Input Variables
 
 - `name` - vpc name
 - `cidr` - vpc cidr
+- `instance_tenancy` - tenancy option for instances launched into the VPC
 - `public_subnets` - list of public subnet cidrs
 - `private_subnets` - list of private subnet cidrs
 - `database_subnets` - list of private RDS subnet cidrs

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "aws_vpc" "mod" {
   cidr_block           = "${var.cidr}"
+  instance_tenancy     = "${var.instance_tenancy}"
   enable_dns_hostnames = "${var.enable_dns_hostnames}"
   enable_dns_support   = "${var.enable_dns_support}"
   tags                 = "${merge(var.tags, map("Name", format("%s", var.name)))}"

--- a/variables.tf
+++ b/variables.tf
@@ -2,6 +2,11 @@ variable "name" {}
 
 variable "cidr" {}
 
+variable "instance_tenancy" {
+  description = "A tenancy option for instances launched into the VPC"
+  default     = "default"
+}
+
 variable "public_subnets" {
   description = "A list of public subnets inside the VPC."
   default     = []


### PR DESCRIPTION
I'm exposing the VPC resource argument `instance_tenancy` as a variable.