### PR TITLE
🐛 #47  Fix issue with string vs bool value with enable_nat_gateway input

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "aws_route" "private_nat_gateway" {
   route_table_id         = "${element(aws_route_table.private.*.id, count.index)}"
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = "${element(aws_nat_gateway.natgw.*.id, count.index)}"
-  count                  = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
+  count                  = "${var.enable_nat_gateway ? length(var.azs) : 0}"
 }
 
 resource "aws_route_table" "private" {
@@ -88,13 +88,13 @@ resource "aws_subnet" "public" {
 
 resource "aws_eip" "nateip" {
   vpc   = true
-  count = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
+  count = "${var.enable_nat_gateway ? length(var.azs) : 0}"
 }
 
 resource "aws_nat_gateway" "natgw" {
   allocation_id = "${element(aws_eip.nateip.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  count         = "${length(var.azs) * lookup(map(var.enable_nat_gateway, 1), "true", 0)}"
+  count         = "${var.enable_nat_gateway ? length(var.azs) : 0}"
 
   depends_on = ["aws_internet_gateway.mod"]
 }


### PR DESCRIPTION
Prior to this change, **only this input value** would create NAT gateways:
```
module "vpc" {
  source = "github.com/terraform-community-modules/tf_aws_vpc"

  enable_nat_gateway = "true"
  ...
}
```
After this change, **any of these input values** will create NAT gateways:
```
module "vpc" {
  source = "github.com/terraform-community-modules/tf_aws_vpc"

  enable_nat_gateway = "true"
  enable_nat_gateway = "1"
  enable_nat_gateway = true
  enable_nat_gateway = 1
  ...
}
```
...and conversly these will not create any NAT gateways:

```
module "vpc" {
  source = "github.com/terraform-community-modules/tf_aws_vpc"

  enable_nat_gateway = "false"
  enable_nat_gateway = "0"
  enable_nat_gateway = false
  enable_nat_gateway = 0
  ...
}
```
