### PR TITLE
✨ #42 Add support for provisioning only a single NAT Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Module Input Variables
 - `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
 - `enable_dns_support` - should be true if you want to use private DNS within the VPC
 - `enable_nat_gateway` - should be true if you want to provision NAT Gateways
+- `single_nat_gateway` - should be true if you want to provision a single shared NAT Gateway across all of your private networks
 - `enable_s3_endpoint` - should be true if you want to provision an S3 endpoint within the VPC
 - `map_public_ip_on_launch` - should be false if you do not want to auto-assign public IP on launch
 - `private_propagating_vgws` - list of VGWs the private route table should propagate

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Module Input Variables
 - `enable_dns_hostnames` - should be true if you want to use private DNS within the VPC
 - `enable_dns_support` - should be true if you want to use private DNS within the VPC
 - `enable_nat_gateway` - should be true if you want to provision NAT Gateways
+- `enable_s3_endpoint` - should be true if you want to provision an S3 endpoint within the VPC
 - `map_public_ip_on_launch` - should be false if you do not want to auto-assign public IP on launch
 - `private_propagating_vgws` - list of VGWs the private route table should propagate
 - `public_propagating_vgws` - list of VGWs the public route table should propagate

--- a/main.tf
+++ b/main.tf
@@ -88,13 +88,13 @@ resource "aws_subnet" "public" {
 
 resource "aws_eip" "nateip" {
   vpc   = true
-  count = "${length(var.azs) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
+  count = "${(var.single_nat_gateway ? 1 : length(var.azs)) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
 }
 
 resource "aws_nat_gateway" "natgw" {
-  allocation_id = "${element(aws_eip.nateip.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
-  count         = "${length(var.azs) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
+  allocation_id = "${element(aws_eip.nateip.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  subnet_id     = "${element(aws_subnet.public.*.id, (var.single_nat_gateway ? 0 : count.index))}"
+  count         = "${(var.single_nat_gateway ? 1 : length(var.azs)) * lookup(map("true", 1, "1", 1), var.enable_nat_gateway, 0)}"
 
   depends_on = ["aws_internet_gateway.mod"]
 }

--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,28 @@ resource "aws_nat_gateway" "natgw" {
   depends_on = ["aws_internet_gateway.mod"]
 }
 
+data "aws_vpc_endpoint_service" "s3" {
+  service = "s3"
+}
+
+resource "aws_vpc_endpoint" "ep" {
+  vpc_id       = "${aws_vpc.mod.id}"
+  service_name = "${data.aws_vpc_endpoint_service.s3.service_name}"
+  count        = "${var.enable_s3_endpoint}"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+  count           = "${var.enable_s3_endpoint ? length(var.private_subnets) : 0}"
+  vpc_endpoint_id = "${aws_vpc_endpoint.ep.id}"
+  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "public_s3" {
+  count           = "${var.enable_s3_endpoint ? length(var.public_subnets) : 0}"
+  vpc_endpoint_id = "${aws_vpc_endpoint.ep.id}"
+  route_table_id  = "${aws_route_table.public.id}"
+}
+
 resource "aws_route_table_association" "private" {
   count          = "${length(var.private_subnets)}"
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,11 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "single_nat_gateway" {
+  description = "should be true if you want to provision a single shared NAT Gateway across all of your private networks"
+  default     = false
+}
+
 variable "enable_s3_endpoint" {
   description = "should be true if you want to provision an S3 endpoint to the VPC"
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,10 @@ variable "enable_nat_gateway" {
   default     = false
 }
 
+variable "enable_s3_endpoint" {
+  description = "should be true if you want to provision an S3 endpoint to the VPC"
+  default     = false
+}
 variable "map_public_ip_on_launch" {
   description = "should be false if you do not want to auto-assign public IP on launch"
   default     = true


### PR DESCRIPTION
~**DEPENDENT ON PR #57**~ (*merged*)

# Sample setup:
  * You have 2 public subnets
  * You have 2 private subnets

## Scenario 1 (high availability)
Prior to this change when you set `enable_nat_gateway=true` you would get the following infrastructure:
  * 2 EIPs (_1 per private subnet_)
  * 2 NAT Gateway (_1 per private subnet_)

While this follows high availability best practices and _should be_ your configuration in a production, sometimes you don't want to incur the cost of having multiple NAT gateways in your dev and testing environments.

## Scenario 2 (low availability)
After this change when you set `enable_nat_gateway=true` and `single_nat_gateway=true` you would get the following infrastructure:
  * 1 EIP (_1 total_)
  * 1 NAT Gateway (_1 total_)

Meaning that you share a single EIP/NAT gateway pairing across all of your private subnets. Reducing costs while maintaining functionality but being far less available. This leaves the onus on the person terraforming to decide whether or not they are ok with the cost/risk tradeoff. 

**Again, this scenario is not intended for a production environment.**
