### PR TITLE
adding dummy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ module has been created.
 
 ```hcl
 module "vpc" {
+  source = "github.com/terraform-community-modules/tf_aws_vpc"
   ...
 }
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ module "bastion" {
   region                      = "eu-west-1"
   iam_instance_profile        = "s3_readonly"
   s3_bucket_name              = "public-keys-demo-bucket"
-  vpc_id                      = "vpc-123456"
-  subnet_ids                  = ["subnet-123456", "subnet-6789123", "subnet-321321"]
+  vpc_id                      = "${module.vpc.id}"
+  subnet_ids                  = "${module.vpc.public_subnets}"
   keys_update_frequency       = "5,20,35,50 * * * *"
   additional_user_data_script = "echo ${module.vpc.depends_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -144,3 +144,29 @@ resource "aws_route_table_association" "public" {
   subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
   route_table_id = "${aws_route_table.public.id}"
 }
+
+resource "null_resource" "dummy_dependency" {
+  depends_on = [
+    "aws_vpc.mod",
+    "aws_internet_gateway.mod",
+    "aws_route_table.public",
+    "aws_route.public_internet_gateway",
+    "aws_route.private_nat_gateway",
+    "aws_route_table.private",
+    "aws_subnet.private",
+    "aws_subnet.database",
+    "aws_db_subnet_group.database",
+    "aws_subnet.elasticache",
+    "aws_elasticache_subnet_group.elasticache",
+    "aws_subnet.public",
+    "aws_eip.nateip",
+    "aws_nat_gateway.natgw",
+    "aws_vpc_endpoint.ep",
+    "aws_vpc_endpoint_route_table_association.private_s3",
+    "aws_vpc_endpoint_route_table_association.public_s3",
+    "aws_route_table_association.private",
+    "aws_route_table_association.database",
+    "aws_route_table_association.elasticache",
+    "aws_route_table_association.public"
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -53,3 +53,7 @@ output "natgw_ids" {
 output "igw_id" {
   value = "${aws_internet_gateway.mod.id}"
 }
+
+output "depends_id" {
+  value = "${null_resource.dummy_dependency.id}"
+}


### PR DESCRIPTION
There are situations where other modules will be used alongside this module, but all the networking components out of this module (such as route tables, NAT Gateways and Internet Gateways) needs to be provisioned first before resources (such as EC2 instances) can be created in other modules. Use of `depends_id` as an output variable provides a suitable workaround.