### PR TITLE
Add vpc_cidr_block output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -26,6 +26,10 @@ output "vpc_id" {
   value = "${aws_vpc.mod.id}"
 }
 
+output "vpc_cidr_block" {
+  value = "${aws_vpc.mod.cidr_block}"
+}
+
 output "public_route_table_ids" {
   value = ["${aws_route_table.public.*.id}"]
 }


### PR DESCRIPTION
I've been peering VPCs and I needed this one in to facilitate some cross-VPC routing rules.

There might be some other use of this output in the long run.