### PR TITLE
Add default_network_acl_id output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "natgw_ids" {
 output "igw_id" {
   value = "${aws_internet_gateway.mod.id}"
 }
+
+output "default_network_acl_id" {
+  value = "${aws_vpc.mod.default_network_acl_id}"
+}


### PR DESCRIPTION
As it has no data resource to acquire it independently form the VPC resource it is good it is returned in an output.