### PR TITLE
Add default_network_acl_id output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Outputs
  - `nat_eips` - list of Elastic IP ids (if any are provisioned)
  - `nat_eips_public_ips` - list of NAT gateways' public Elastic IP's (if any are provisioned)
  - `igw_id` - Internet Gateway id string
+ - `default_network_acl_id` - VPC default network ACL id
 
 **NOTE**: previous versions of this module returned a single string as a route
 table ID, while this version returns a list.

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "natgw_ids" {
 output "igw_id" {
   value = "${aws_internet_gateway.mod.id}"
 }
+
+output "default_network_acl_id" {
+  value = "${aws_vpc.mod.default_network_acl_id}"
+}


### PR DESCRIPTION
Because is the only way to acquire this value currently using Terraform.